### PR TITLE
1.5.2 update and srg names

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,32 +18,20 @@
 	</target>
 	
 	<target name="recompile">
-		<exec dir="${dir.development}\mcp" executable="cmd" os="Windows 7">
+		<exec dir="${dir.development}\mcp" executable="cmd" osfamily="windows">
 			<arg line="/c recompile.bat" />
 		</exec>
-		<exec dir="${dir.development}\mcp" executable="cmd" os="Windows 8">
-			<arg line="/c recompile.bat" />
-		</exec>
-		<exec dir="${dir.development}\mcp" executable="bash" os="Linux">
-			<arg line="recompile.sh" />
-		</exec>
-		<exec dir="${dir.development}\mcp" executable="bash" os="Mac OS X">
+		<exec dir="${dir.development}\mcp" executable="bash" osfamily="unix">
 			<arg line="recompile.sh" />
 		</exec>
 	</target>
 	
 	<target name="reobfuscate">
-		<exec dir="${dir.development}\mcp" executable="cmd" os="Windows 7">
-			<arg line="/c reobfuscate.bat" />
+		<exec dir="${dir.development}\mcp" executable="cmd" osfamily="windows">
+			<arg line="/c reobfuscate_srg.bat" />
 		</exec>
-		<exec dir="${dir.development}\mcp" executable="cmd" os="Windows 8">
-			<arg line="/c reobfuscate.bat" />
-		</exec>
-		<exec dir="${dir.development}\mcp" executable="bash" os="Linux">
-			<arg line="reobfuscate.sh" />
-		</exec>
-		<exec dir="${dir.development}\mcp" executable="bash" os="Mac OS X">
-			<arg line="reobfuscate.sh" />
+		<exec dir="${dir.development}\mcp" executable="bash" osfamily="unix">
+			<arg line="reobfuscate_srg.sh" />
 		</exec>
 	</target>
 	

--- a/common/mrj/abm/ItemBackpackBase.java
+++ b/common/mrj/abm/ItemBackpackBase.java
@@ -229,8 +229,7 @@ public class ItemBackpackBase extends Item {
 	//register icons
 	@Override
 	@SideOnly(Side.CLIENT)
-    //public void func_94581_a(IconRegister iconRegister)
-	public void updateIcons(IconRegister iconRegister)
+	public void registerIcons(IconRegister iconRegister)
     {
 		icons = new Icon[2];
 		icons[0] = iconRegister.registerIcon("advancedbackpackmod:backpack32colorless");

--- a/common/mrj/abm/ItemBackpackMagic.java
+++ b/common/mrj/abm/ItemBackpackMagic.java
@@ -123,8 +123,7 @@ public class ItemBackpackMagic extends ItemBackpackBase {
     }
 	
 	@Override
-    //public void func_94581_a(IconRegister iconRegister)
-	public void updateIcons(IconRegister iconRegister)
+	public void registerIcons(IconRegister iconRegister)
     {
 		icons = new Icon[2];
 		icons[0] = iconRegister.registerIcon("advancedbackpackmod:backpack32colorless");

--- a/common/mrj/abm/ItemDiamondEye.java
+++ b/common/mrj/abm/ItemDiamondEye.java
@@ -12,8 +12,9 @@ public class ItemDiamondEye extends Item {
 		// TODO Auto-generated constructor stub
 	}
 	
-	public void updateIcons(IconRegister iconRegister)
+	@Override
+	public void registerIcons(IconRegister iconRegister)
     {
-		this.iconIndex = iconRegister.registerIcon("advancedbackpackmod:diamondeye");
+		this.itemIcon = iconRegister.registerIcon("advancedbackpackmod:diamondeye");
     }
 }

--- a/common/mrj/abm/ItemNetherPowerCore.java
+++ b/common/mrj/abm/ItemNetherPowerCore.java
@@ -12,8 +12,9 @@ public class ItemNetherPowerCore extends Item {
 		// TODO Auto-generated constructor stub
 	}
 	
-	public void updateIcons(IconRegister iconRegister)
+	@Override
+	public void registerIcons(IconRegister iconRegister)
     {
-		this.iconIndex = iconRegister.registerIcon("advancedbackpackmod:netherpowercore");
+		this.itemIcon = iconRegister.registerIcon("advancedbackpackmod:netherpowercore");
     }
 }


### PR DESCRIPTION
I updated the mod for developing in Minecraft 1.5.2 and MinecraftForge v7.8.0.734. I also modified the build.xml to use reobfuscate_srg instead of normal reobfuscate, which will allow the mod to work between minor version of Minecraft (so the changes I made will make the mod work in both 1.5.2 and 1.5.1)
